### PR TITLE
Allowing matches to be reserve sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ You can also retrieve the matches for any team if you know their FIFA code by pa
 
     Example: [url]/matches/country?fifa_code=USA
 
+==Optional Parameters
+
+You can append `?order=desc` to any query to reverse sort the matches by `match_number`.
+
 == EXAMPLE RESPONSES
 
 MATCH API

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,38 +1,47 @@
 class MatchesController < ApplicationController
 
+  def ordered_class
+    klass = Match
+    if params[:order].present? && params[:order].upcase == 'DESC'
+      klass.order('match_number DESC')
+    else
+      klass.order(:match_number)
+    end
+  end
+
   def index
-    @matches = Match.all.order(:match_number)
+    @matches = ordered_class.all
     render 'index.json.rabl'
   end
 
   def current
-    @matches = Match.where(status: "in progress")
+    @matches = ordered_class.where(status: "in progress")
     render 'index.json.rabl'
   end
 
   def complete
-    @matches = Match.where(status: "completed")
+    @matches = ordered_class.where(status: "completed")
     render 'index.json.rabl'
   end
 
   def future
-    @matches = Match.where(status: "future")
+    @matches = ordered_class.where(status: "future")
     render 'index.json.rabl'
   end
 
   def country
     @team = Team.where(fifa_code: params['fifa_code']).first
-    @matches = Match.where("home_team_id = ? OR away_team_id = ?", @team.id, @team.id)
+    @matches = ordered_class.where("home_team_id = ? OR away_team_id = ?", @team.id, @team.id)
     render 'index.json.rabl'
   end
 
   def today
-    @matches = Match.today
+    @matches = ordered_class.today
     render 'index.json.rabl'
   end
 
   def tomorrow
-    @matches = Match.tomorrow
+    @matches = ordered_class.tomorrow
     render 'index.json.rabl'
   end
 end


### PR DESCRIPTION
Could potentially handy for clients that want to show the newest matches at the top, with a query to http://worldcup.sfg.io/matches/current?order=desc.
