### PR TITLE
Tweaking markdown to be GH compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-== ABOUT
+# ABOUT
 
 This is a simple backend for a scraper that grabs current world cup results and outputs them as JSON.
 
-== SETUP
+# SETUP
 
 * Clone the repo
 
-* ```rake setup:generate_teams``` to generate the teams
+* ```rake db:setup setup:generate_teams``` to initialize the database and generate the teams
 
 * Run the following two tasks as cron jobs, to pull in data with whatever time frame you want (every 5 minutes for example):
 ```rake fifa:get_group_results``` (This pulls in the standings of the group stages)
 ```rake fifa:get_all_matches``` (This pulls in all matches and updates any that need updating)
 
-==TODO
+## TODO
 
 * Static landing page
 * Add CSS class to determine knocked out teams
 
-==ENDPOINTS
+## ENDPOINTS
 
     [url]/teams/
 for a list of teams with group ID and FIFA code
@@ -28,7 +28,7 @@ for current results (wins, losses, draws, goals for, goals against, knock out st
     [url]/matches/
 for all matches (Example JSON object at the bottom of this README)
 
-==OTHER ENDPOINTS
+## OTHER ENDPOINTS
 
     [url]/matches/today/
     [url]/matches/tomorrow/
@@ -39,7 +39,7 @@ You can also retrieve the matches for any team if you know their FIFA code by pa
 
     Example: [url]/matches/country?fifa_code=USA
 
-==Optional Parameters
+## Optional Parameters
 
 You can append `?by_date=desc` to any query tosort the matches by furthest in the future to furthest in the past. `?by_date=asc` does past to future.
 
@@ -47,7 +47,7 @@ You can append `?by_date=desc` to any query tosort the matches by furthest in th
 
 Gives you today's matches in reverse order from latest to earliest.
 
-== EXAMPLE RESPONSES
+## EXAMPLE RESPONSES
 
 MATCH API
 
@@ -88,7 +88,7 @@ updated_at: "2014-06-14T01:06:52.484-05:00"
 },
 ```
 
-== TRY IT OUT (We'll keep this up through the duration of the World Cup)
+## TRY IT OUT (We'll keep this up through the duration of the World Cup)
 
 http://worldcup.sfg.io/matches
 
@@ -98,7 +98,7 @@ http://worldcup.sfg.io/group_results
 
 http://worldcup.sfg.io/teams
 
-== BACKGROUND
+## BACKGROUND
 
 You can read a blog post about building the API here:
 http://softwareforgood.com/soccer-good/


### PR DESCRIPTION
Also adding in minor rake task.

GH uses `#`s instead of `=`s for headers: https://help.github.com/articles/markdown-basics.  Making sure there is a space between header markdown and text.
