### PR TITLE
Handle CORS correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ group :doc do
   gem 'sdoc', require: false
 end
 
+gem 'rack-cors', :require => 'rack/cors'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     rabl (0.10.1)
       activesupport (>= 2.3.14)
     rack (1.5.2)
+    rack-cors (0.2.9)
     rack-pjax (0.7.0)
       nokogiri (~> 1.5)
       rack (~> 1.3)
@@ -165,6 +166,7 @@ DEPENDENCIES
   oj
   pry-rails
   rabl
+  rack-cors
   rails (= 4.0.2)
   rails_admin
   sass-rails (~> 4.0.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,11 @@ module WorldCupJson
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.middleware.use Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
CORS or Cross-origin resource sharing is a way to get around the "access-control-allow-origin" error safely.
