### PR TITLE
Teams now have country codes

### DIFF
--- a/db/migrate/20140702031332_add_country_code_to_teams.rb
+++ b/db/migrate/20140702031332_add_country_code_to_teams.rb
@@ -1,0 +1,5 @@
+class AddCountryCodeToTeams < ActiveRecord::Migration
+  def change
+    add_column :teams, :country_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140628190631) do
+ActiveRecord::Schema.define(version: 20140702031332) do
 
   create_table "events", force: true do |t|
     t.string   "type_of_event"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 20140628190631) do
     t.boolean  "knocked_out"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "country_code"
   end
 
 end

--- a/lib/tasks/get_country_codes.rake
+++ b/lib/tasks/get_country_codes.rake
@@ -1,0 +1,17 @@
+require 'open-uri'
+require 'json'
+
+namespace :team do
+  task get_all_country_codes: :environment do
+    API_ENDPOINT = "http://restcountries.eu/rest/v1/name"
+    Team.all.each do |team|
+      country = team.country
+      country = 'Great%20Britain' if country == "England"
+      country = 'South%20Korea' if country == "Korea Republic"
+      puts API_ENDPOINT+'/'+country
+      json = JSON.parse(open(API_ENDPOINT+"/"+country.gsub(' ', '%20')).read)[0]
+      team.country_code = json['alpha2Code']
+      team.save
+    end
+  end
+end


### PR DESCRIPTION
I was building a d3 visualization and felt as though it would be useful for teams to have a country code column.  This comes in handy when you are using other APIs to get country flags, for example.  

Included in this pull request is the migration and a rake task that can be run as follows: 

```bash 
 rake team:get_all_country_codes
```
Cheers, 
Matt