### PR TITLE
Add world-cup-2018-cli-dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ http://worldcup.sfg.io/teams
 
 * https://github.com/pedsm/liveCup (React.js based dashboard with live updates designed for TVs and Computers)
 
+* https://github.com/cedricblondeau/world-cup-2018-cli-dashboard (CLI Dashboard that displays live updates of the current game, today's schedule and groups, built with react-blessed)
+
 ## PROJECTS USING THIS API IN 2014
 
 * http://alexb.ninja/wc


### PR DESCRIPTION
Thanks for this awesome API.

`world-cup-2018-cli-dashboard` uses the API to display live updates of the current game, today's schedule and groups in a CLI dashboard built with [react-blessed](https://github.com/Yomguithereal/react-blessed).