### PR TITLE
Add world-cup-2022-cli-dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ The response includes the same data output as the regular GET call without param
 - https://github.com/cyrusDev1/qatar-worldcup
   (Vue Js Web App to find the matches, scores and rankings of the Qatar 2022 world cup in real time.)
 
+- https://github.com/cedricblondeau/world-cup-2022-cli-dashboard
+  (Watch live matches in your terminal)
+
 ## PROJECTS USING THIS API IN 2018
 
 <details><summary>2018 projects submitted</summary>


### PR DESCRIPTION
Thanks for reviving this project! This is awesome work. 🚀 

Adding [world-cup-2022-cli-dashboard](https://github.com/cedricblondeau/world-cup-2022-cli-dashboard) to the README. It's a reboot of [world-cup-2018-cli-dashboard](https://github.com/cedricblondeau/world-cup-2018-cli-dashboard).